### PR TITLE
Fixed a broken reference in the SQL file

### DIFF
--- a/Database Definition and Scripts/SQL Server - Modern/SQL Server SQL EasyBuyCyclesModern Clear All Tables.sql
+++ b/Database Definition and Scripts/SQL Server - Modern/SQL Server SQL EasyBuyCyclesModern Clear All Tables.sql
@@ -3,7 +3,7 @@
 
 -- USE "EasyBuyCycles";
 -- USE "EasyBuyCyclesDev";
--- USE "EasyBuyCyclesLegacy";
+-- USE "EasyBuyCyclesModern";
 
 -- DELETE FROM [dbo].[OrderItem]
 -- DELETE FROM [dbo].[Order]


### PR DESCRIPTION
The SQL file for the Modern Database referenced a table in the legacy database. This change fixes that so it is looking at the right table.